### PR TITLE
Bs 1887

### DIFF
--- a/macgyver/TaskGroup.cpp
+++ b/macgyver/TaskGroup.cpp
@@ -1,5 +1,38 @@
 #include "TaskGroup.h"
 
+struct Fmi::TaskGroup::Task
+{
+  std::string name;
+  std::atomic<bool> done;
+  std::atomic<bool> failed;
+  Fmi::TaskGroup* tg;
+  std::shared_future<void> f;
+
+  Task(const std::string& name, std::function<void()> task, Fmi::TaskGroup* tg)
+    : name(name)
+    , done(false)
+    , failed(false)
+    , tg(tg)
+    , f(std::async(std::launch::async, [this, task]() { execute(task); }).share())
+    {
+    }
+
+private:
+    void execute(std::function<void()> task)
+    {
+      try {
+        task();
+        done = true;
+        tg->notify();
+      } catch (...) {
+        done = true;
+        failed = true;
+        tg->notify();
+        throw;
+      }
+    }
+};
+
 Fmi::TaskGroup::TaskGroup(std::size_t max_parallel_tasks)
   : max_parallel_tasks(max_parallel_tasks)
   , counter(0)
@@ -17,20 +50,8 @@ void Fmi::TaskGroup::add(const std::string& name, std::function<void()> task)
     wait_some();
   }
 
-  std::function<void()> task_impl = [this, task]()
-    {
-      try {
-	task();
-      } catch (...) {
-	notify();
-	throw;
-      }
-
-      notify();
-    };
-
   std::unique_lock<std::mutex> lock(mutex);
-  task_list.push_back(std::make_pair(name, std::async(std::launch::async, task_impl).share()));
+  task_list.emplace_back(new Task(name, task, this));
 }
 
 void Fmi::TaskGroup::wait()
@@ -64,47 +85,45 @@ Fmi::TaskGroup::on_task_error(std::function<void(const std::string&)> callback)
 
 bool Fmi::TaskGroup::wait_some()
 {
-  std::queue<std::pair<std::string, std::shared_future<void> > > finished_tasks;
+  std::queue<std::shared_ptr<Task> > finished_tasks;
   std::unique_lock<std::mutex> lock(mutex);
-  if (task_list.empty()) {
-    return false;
-  } else {
-    extract_finished(finished_tasks);
-    if (finished_tasks.empty()) {
-      cond.wait(lock);
-      extract_finished(finished_tasks);
-    }
-  }
-
+  cond.wait(lock, [this, &finished_tasks]() { return extract_finished(finished_tasks); });
   lock.unlock();
 
-  while (not finished_tasks.empty()) {
-    auto item = finished_tasks.front();
-    finished_tasks.pop();
-    try {
-      item.second.get();
-      signal_task_ended(item.first);
-    } catch (...) {
+  if (finished_tasks.empty()) {
+    return false;
+  } else {
+    while (not finished_tasks.empty()) {
+      auto item = finished_tasks.front();
+      finished_tasks.pop();
+      try {
+        item->f.get();
+        signal_task_ended(item->name);
+      } catch (...) {
       num_failures++;
-      signal_task_failed(item.first);
+      signal_task_failed(item->name);
+      }
     }
+    return true;
   }
-
-  return true;
 }
 
-void
-Fmi::TaskGroup::extract_finished(std::queue<std::pair<std::string, std::shared_future<void> > >& finished_tasks)
+bool
+Fmi::TaskGroup::extract_finished(std::queue<std::shared_ptr<Fmi::TaskGroup::Task> >& finished_tasks)
 {
+  bool empty = task_list.empty();
+  bool found = false;
   iterator curr, next;
   for (curr = task_list.begin(); curr != task_list.end(); curr = next) {
     next = curr;
     ++next;
-    if (curr->second.wait_for(std::chrono::seconds(0)) == std::future_status::ready) {
+    if ((*curr)->done) {
+      found = true;
       finished_tasks.push(*curr);
       task_list.erase(curr);
     }
   }
+  return empty || found;
 }
 
 void Fmi::TaskGroup::notify()

--- a/macgyver/TaskGroup.cpp
+++ b/macgyver/TaskGroup.cpp
@@ -4,14 +4,12 @@ struct Fmi::TaskGroup::Task
 {
   std::string name;
   std::atomic<bool> done;
-  std::atomic<bool> failed;
   Fmi::TaskGroup* tg;
   std::shared_future<void> f;
 
   Task(const std::string& name, std::function<void()> task, Fmi::TaskGroup* tg)
     : name(name)
     , done(false)
-    , failed(false)
     , tg(tg)
     , f(std::async(std::launch::async, [this, task]() { execute(task); }).share())
     {
@@ -26,7 +24,6 @@ private:
         tg->notify();
       } catch (...) {
         done = true;
-        failed = true;
         tg->notify();
         throw;
       }

--- a/macgyver/TaskGroup.h
+++ b/macgyver/TaskGroup.h
@@ -30,7 +30,6 @@ class TaskGroup
 
  private:
   bool wait_some();
-  void remove_finished();
   void extract_finished(std::queue<std::pair<std::string, std::shared_future<void> > >& finished_tasks);
   void notify();
 

--- a/macgyver/TaskGroup.h
+++ b/macgyver/TaskGroup.h
@@ -5,6 +5,7 @@
 #include <functional>
 #include <future>
 #include <list>
+#include <memory>
 #include <mutex>
 #include <queue>
 #include <string>
@@ -14,6 +15,7 @@ namespace Fmi {
 
 class TaskGroup
 {
+  struct Task;
  public:
   TaskGroup(std::size_t max_parallel_tasks = 30);
   virtual ~TaskGroup();
@@ -30,18 +32,18 @@ class TaskGroup
 
  private:
   bool wait_some();
-  void extract_finished(std::queue<std::pair<std::string, std::shared_future<void> > >& finished_tasks);
+  bool extract_finished(std::queue<std::shared_ptr<Task> >& finished_tasks);
   void notify();
 
  private:
-  typedef std::list<std::pair<std::string, std::shared_future<void> > >::iterator iterator;
+  typedef std::list<std::shared_ptr<Task> >::iterator iterator;
 
   mutable std::mutex mutex;
   std::condition_variable cond;
   std::size_t max_parallel_tasks;
   std::size_t counter;
   std::atomic<std::size_t> num_failures;
-  std::list<std::pair<std::string, std::shared_future<void> > > task_list;
+  std::list<std::shared_ptr<Task> > task_list;
   boost::signals2::signal<void(const std::string&)> signal_task_ended;
   boost::signals2::signal<void(const std::string&)> signal_task_failed;
 };


### PR DESCRIPTION
Fmi::TaskGroup: reimplement task handling to fix race conditions when waiting for tasks to end

Problems appeared as random freeze in unit tests but it was real Fmi::TaskGroup problem