### PR TITLE
Fix issues from the security audit

### DIFF
--- a/macgyver/Pool.h
+++ b/macgyver/Pool.h
@@ -346,7 +346,7 @@ namespace Fmi
 
                 for (std::size_t i = 0; i < start_size; ++i)
                 {
-                    task_group.add("pool_item_init[" + Fmi::to_string(i+1) + "]", grow);
+                    task_group.add("ini-pool-" + Fmi::to_string(i+1), grow);
                 }
 
                 task_group.on_task_error(init_task_error);

--- a/macgyver/PostgreSQLConnection.cpp
+++ b/macgyver/PostgreSQLConnection.cpp
@@ -118,6 +118,36 @@ PostgreSQLConnectionOptions::operator std::string() const
   return ss.str();
 }
 
+std::string PostgreSQLConnectionOptions::toString(bool hidePassword) const
+{
+  std::ostringstream ss;
+
+  // clang-format off
+  ss << "host="      << host
+     << " dbname="   << database
+     << " port="     << port
+     << " user="     << username;
+
+  if (hidePassword)
+  {
+    ss << " password=***";
+  }
+  else
+  {
+    ss << " password=" << password;
+  }
+#if 0
+  ss << " client_encoding=" << encoding
+#endif
+       ;
+  // clang-format on
+
+  if (connect_timeout > 0)
+    ss << " connect_timeout=" << connect_timeout;
+
+  return ss.str();
+}
+
 
 // ----------------------------------------------------------------------
 

--- a/macgyver/PostgreSQLConnection.cpp
+++ b/macgyver/PostgreSQLConnection.cpp
@@ -13,6 +13,7 @@
 #include <chrono>
 #include <iostream>
 #include <optional>
+#include <regex>
 #include <sstream>
 #include <variant>
 #include <vector>
@@ -89,7 +90,9 @@ PostgreSQLConnectionOptions::PostgreSQLConnectionOptions(const std::string& conn
   }
   catch (...)
   {
-    throw Fmi::Exception::Trace(BCP, "Failed to parse connection string '" + conn_str + "'");
+    std::regex pwmask{R"(\bpassword=\S+)"};
+    const auto cstr{std::regex_replace(conn_str, pwmask, "password=***")};
+    throw Fmi::Exception::Trace(BCP, "Failed to parse connection string '" + cstr + "'");
   }
 }
 

--- a/macgyver/PostgreSQLConnection.h
+++ b/macgyver/PostgreSQLConnection.h
@@ -48,6 +48,7 @@ struct PostgreSQLConnectionOptions
   PostgreSQLConnectionOptions(const std::string& conn_str);
 
   operator std::string() const;
+  std::string toString(bool hidePassword = true) const;
 
   inline PostgreSQLConnectionId getId() const { return {host, port, database}; }
 };

--- a/macgyver/PostgreSQLConnectionImpl.cpp
+++ b/macgyver/PostgreSQLConnectionImpl.cpp
@@ -273,7 +273,7 @@ std::shared_ptr<pqxx::connection> PostgreSQLConnection::Impl::open_internal(std:
 
     std::shared_ptr<pqxx::connection> connection;
 
-    std::string conn_str = static_cast<std::string>(itsConnectionOptions);
+    const auto conn_str{itsConnectionOptions.toString(false)};
 
     std::exception_ptr last_exception;
 

--- a/test/PostgreSQLConnectionOptionsTest.cpp
+++ b/test/PostgreSQLConnectionOptionsTest.cpp
@@ -57,6 +57,43 @@ void parse_options_1()
   TEST_PASSED();
 }
 
+void hide_password()
+{
+  const std::map<std::string, std::string> testcases{
+    // password at the beginning
+    {"password=mypassword host=db.example.com dbname=example port=fail user=foo",
+     "Failed to parse connection string 'password=*** host=db.example.com dbname=example port=fail user=foo'"},
+    // password at the end
+    {"host=db.example.com dbname=example port=fail user=foo password=mypassword",
+     "Failed to parse connection string 'host=db.example.com dbname=example port=fail user=foo password=***'"},
+    // password in the middle
+    {"host=db.example.com dbname=example port=fail  password=mypassword\tuser=foo",
+     "Failed to parse connection string 'host=db.example.com dbname=example port=fail  password=***\tuser=foo'"},
+    // password-like username, should be left as is
+    {"host=db.example.com dbname=example port=fail user=foopassword=mypassword",
+     "Failed to parse connection string 'host=db.example.com dbname=example port=fail user=foopassword=mypassword'"}
+  };
+
+  for (const auto& [input, expected] : testcases)
+  {
+    try
+    {
+      Fmi::Database::PostgreSQLConnectionOptions opt(input);
+    }
+    catch (const Fmi::Exception& t)
+    {
+      const std::string what{t.getWhat()};
+      if (what != expected)
+      {
+        TEST_FAILED("'" + what + "' <=> '" + expected + "'");
+      }
+      else continue;
+    }
+    TEST_FAILED("expected exception");
+  }
+  TEST_PASSED();
+}
+
 void id_format()
 {
   using Fmi::Database::PostgreSQLConnectionId;
@@ -84,6 +121,7 @@ class tests : public tframe::tests
   void test(void)
   {
     TEST(parse_options_1);
+    TEST(hide_password);
     TEST(id_format);
   }
 };

--- a/test/PostgreSQLConnectionOptionsTest.cpp
+++ b/test/PostgreSQLConnectionOptionsTest.cpp
@@ -57,7 +57,7 @@ void parse_options_1()
   TEST_PASSED();
 }
 
-void hide_password()
+void hide_password_in_exception()
 {
   const std::map<std::string, std::string> testcases{
     // password at the beginning
@@ -94,6 +94,29 @@ void hide_password()
   TEST_PASSED();
 }
 
+void hide_password_in_toString()
+{
+  const std::string input{"password=mypassword host=db.example.com dbname=example port=1234 user=foo"};
+  Fmi::Database::PostgreSQLConnectionOptions opts{input};
+  {
+    const auto str{opts.toString(true)};
+    const std::string expected_without_pw{"host=db.example.com dbname=example port=1234 user=foo password=***"};    
+    if (str != expected_without_pw)
+    {
+      TEST_FAILED("'" + str + "' <=> '" + expected_without_pw + "'");
+    }
+  }
+  {
+    const auto str{opts.toString(false)};
+    const std::string expected_with_pw{"host=db.example.com dbname=example port=1234 user=foo password=mypassword"};
+    if (str != expected_with_pw)
+    {
+      TEST_FAILED("'" + str + "' <=> '" + expected_with_pw + "'");
+    }
+  }
+  TEST_PASSED();
+}
+
 void id_format()
 {
   using Fmi::Database::PostgreSQLConnectionId;
@@ -121,7 +144,8 @@ class tests : public tframe::tests
   void test(void)
   {
     TEST(parse_options_1);
-    TEST(hide_password);
+    TEST(hide_password_in_exception);
+    TEST(hide_password_in_toString);
     TEST(id_format);
   }
 };


### PR DESCRIPTION
Fix few issues from the security audit in SmartMet server code (BRAINSTORM-3396).

One commit fixes object pool thread names to conform with the current thread naming scheme.