### PR TITLE
ThreadPool: optional timeout for graceful shutdown

### DIFF
--- a/macgyver/ThreadPool.h
+++ b/macgyver/ThreadPool.h
@@ -8,7 +8,8 @@
 
 #pragma once
 #include "ThreadName.h"
-#include <boost/date_time/posix_time/posix_time.hpp>
+#include <boost/chrono/duration.hpp>
+#include <boost/chrono/system_clocks.hpp>
 #include <boost/thread.hpp>
 #include <fmt/format.h>
 #include <functional>
@@ -285,11 +286,13 @@ class ThreadPool
     {
       if (theTimeoutSeconds > 0.0)
       {
-        const int stepMillis = 50;
-        long stepsLeft = static_cast<long>((theTimeoutSeconds * 1000.0) / stepMillis) + 1;
-        while (itsWorkerCount > 0 && stepsLeft-- > 0)
+        const auto deadline =
+            boost::chrono::steady_clock::now() +
+            boost::chrono::milliseconds(static_cast<long long>(theTimeoutSeconds * 1000.0));
+        while (itsWorkerCount > 0)
         {
-          itsWorkerDeathEvent.timed_wait(lock, boost::posix_time::milliseconds(stepMillis));
+          if (itsWorkerDeathEvent.wait_until(lock, deadline) == boost::cv_status::timeout)
+            break;
         }
         timedOut = (itsWorkerCount > 0);
       }

--- a/macgyver/ThreadPool.h
+++ b/macgyver/ThreadPool.h
@@ -18,6 +18,7 @@
 #include <queue>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 namespace Fmi
 {
@@ -307,14 +308,22 @@ class ThreadPool
 
     if (!itsShutdownGracefully || timedOut)
     {
-      for (auto it = itsWorkers.begin(); it != itsWorkers.end(); ++it)
-      {
-        (*it)->interrupt();
-      }
+      // Snapshot the live workers while holding the lock, then interrupt and join them
+      // without it. We must not hold the lock across join() (a dying worker needs it in
+      // workerDied()), and we must not iterate itsWorkers while joining, because each
+      // worker erases itself from itsWorkers as it dies - which would invalidate the
+      // iterator. Holding the shared_ptrs also keeps every Worker (and its thread object)
+      // alive until after its join(), so none is destroyed while still joinable.
+      std::vector<std::shared_ptr<Worker<PoolType> > > workers(itsWorkers.begin(),
+                                                               itsWorkers.end());
       lock.unlock();
-      for (auto it = itsWorkers.begin(); it != itsWorkers.end(); ++it)
+      for (auto& worker : workers)
       {
-        (*it)->join();
+        worker->interrupt();
+      }
+      for (auto& worker : workers)
+      {
+        worker->join();
       }
       lock.lock();
     }

--- a/macgyver/ThreadPool.h
+++ b/macgyver/ThreadPool.h
@@ -270,9 +270,9 @@ class ThreadPool
    *
    * \param theTimeoutSeconds When > 0 and shutting down gracefully, wait at
    *        most this long for active tasks to finish; if the timeout elapses,
-   *        fall back to interrupting the workers so shutdown cannot hang on a
-   *        stuck task. A value <= 0 waits indefinitely (the historical
-   *        behaviour). Pending queued tasks are never run in either case.
+   *        fall back to interrupting the workers (best effort; tasks must reach
+   *        a Boost interruption point for interruption to take effect). A value
+   *        <= 0 waits indefinitely (the historical behaviour). Pending queued tasks are never run.
    */
   // ======================================================================
 

--- a/macgyver/ThreadPool.h
+++ b/macgyver/ThreadPool.h
@@ -8,6 +8,7 @@
 
 #pragma once
 #include "ThreadName.h"
+#include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/thread.hpp>
 #include <fmt/format.h>
 #include <functional>
@@ -261,25 +262,47 @@ class ThreadPool
    * \brief Stops ThreadPool activity
    *
    * Stops the ThreadPool activity. Use this to shutdown the pool.
-   * If itsShutdownGracefully is true, waits for
-   * active threads to finish executing the current task. If not, terminates
-   * all threads "immediately" (as quickly as they can be interrupted).
+   * If itsShutdownGracefully is true, waits for active threads to finish
+   * executing the current task. If not, terminates all threads "immediately"
+   * (as quickly as they can be interrupted).
+   *
+   * \param theTimeoutSeconds When > 0 and shutting down gracefully, wait at
+   *        most this long for active tasks to finish; if the timeout elapses,
+   *        fall back to interrupting the workers so shutdown cannot hang on a
+   *        stuck task. A value <= 0 waits indefinitely (the historical
+   *        behaviour). Pending queued tasks are never run in either case.
    */
   // ======================================================================
 
-  void shutdown()
+  void shutdown(double theTimeoutSeconds = 0.0)
   {
     Lock lock(itsMutex);
     itsTargetWorkerCount = 0;
     itsDataEvent.notify_all();
+
+    bool timedOut = false;
     if (itsShutdownGracefully)
     {
-      while (itsWorkerCount > 0)
+      if (theTimeoutSeconds > 0.0)
       {
-        itsWorkerDeathEvent.wait(lock);
+        const int stepMillis = 50;
+        long stepsLeft = static_cast<long>((theTimeoutSeconds * 1000.0) / stepMillis) + 1;
+        while (itsWorkerCount > 0 && stepsLeft-- > 0)
+        {
+          itsWorkerDeathEvent.timed_wait(lock, boost::posix_time::milliseconds(stepMillis));
+        }
+        timedOut = (itsWorkerCount > 0);
+      }
+      else
+      {
+        while (itsWorkerCount > 0)
+        {
+          itsWorkerDeathEvent.wait(lock);
+        }
       }
     }
-    else
+
+    if (!itsShutdownGracefully || timedOut)
     {
       for (auto it = itsWorkers.begin(); it != itsWorkers.end(); ++it)
       {
@@ -290,6 +313,7 @@ class ThreadPool
       {
         (*it)->join();
       }
+      lock.lock();
     }
 
     itsAllIdleEvent.notify_one();

--- a/test/ThreadPoolTest.cpp
+++ b/test/ThreadPoolTest.cpp
@@ -109,8 +109,10 @@ BOOST_AUTO_TEST_CASE(shutdown_timeout_allows_task_to_finish)
       });
   BOOST_REQUIRE(inserted);
 
-  while (!started)
+  const auto start_deadline = boost::chrono::steady_clock::now() + boost::chrono::seconds(2);
+  while (!started && boost::chrono::steady_clock::now() < start_deadline)
     boost::this_thread::sleep_for(boost::chrono::milliseconds(5));
+  BOOST_REQUIRE_MESSAGE(started, "worker did not start task within 2 seconds");
 
   const auto t0 = boost::chrono::steady_clock::now();
   pool.shutdown(5.0);  // generous timeout: the 200 ms task finishes before it elapses

--- a/test/ThreadPoolTest.cpp
+++ b/test/ThreadPoolTest.cpp
@@ -73,9 +73,10 @@ BOOST_AUTO_TEST_CASE(shutdown_timeout_interrupts_stuck_task)
   BOOST_REQUIRE(inserted);
 
   // Make sure a worker has actually picked up the task and is sleeping inside it.
-  while (!started)
+  const auto start_deadline = boost::chrono::steady_clock::now() + boost::chrono::seconds(2);
+  while (!started && boost::chrono::steady_clock::now() < start_deadline)
     boost::this_thread::sleep_for(boost::chrono::milliseconds(5));
-
+  BOOST_REQUIRE_MESSAGE(started, "worker did not start task within 2 seconds");
   const auto t0 = boost::chrono::steady_clock::now();
   pool.shutdown(0.5);  // graceful, but bail out after 0.5 s and interrupt
   const auto elapsed_ms = boost::chrono::duration_cast<boost::chrono::milliseconds>(

--- a/test/ThreadPoolTest.cpp
+++ b/test/ThreadPoolTest.cpp
@@ -49,3 +49,75 @@ BOOST_AUTO_TEST_CASE(test_thread_pool_1)
   pool.shutdown();
   BOOST_CHECK_EQUAL(count, 10);
 }
+
+// A graceful shutdown with a timeout must not wait forever for a stuck task: once the
+// timeout elapses it falls back to interrupting the workers. The task sleeps with
+// boost::this_thread::sleep_for, which is a boost interruption point (std::this_thread's
+// sleep is not), so interrupt() actually aborts it.
+BOOST_AUTO_TEST_CASE(shutdown_timeout_interrupts_stuck_task)
+{
+  std::atomic<bool> started{false};
+  std::atomic<bool> completed{false};
+
+  Fmi::ThreadPool::ThreadPool pool(1, 10);
+  pool.setGracefulShutdown(true);
+  pool.start();
+
+  bool inserted = pool.schedule(
+      [&started, &completed]()
+      {
+        started = true;
+        boost::this_thread::sleep_for(boost::chrono::seconds(10));
+        completed = true;  // must NOT be reached: the task is interrupted first
+      });
+  BOOST_REQUIRE(inserted);
+
+  // Make sure a worker has actually picked up the task and is sleeping inside it.
+  while (!started)
+    boost::this_thread::sleep_for(boost::chrono::milliseconds(5));
+
+  const auto t0 = boost::chrono::steady_clock::now();
+  pool.shutdown(0.5);  // graceful, but bail out after 0.5 s and interrupt
+  const auto elapsed_ms = boost::chrono::duration_cast<boost::chrono::milliseconds>(
+                              boost::chrono::steady_clock::now() - t0)
+                              .count();
+
+  BOOST_TEST_MESSAGE("shutdown(0.5) with a 10 s task returned after " << elapsed_ms << " ms");
+  BOOST_CHECK(!completed);           // task was interrupted, not run to completion
+  BOOST_CHECK_LT(elapsed_ms, 5000);  // did not wait for the full 10 s task
+  BOOST_CHECK_GE(elapsed_ms, 300);   // did wait roughly the timeout before interrupting
+}
+
+// With a generous timeout the currently running task still finishes gracefully; the
+// timeout only bounds the wait, it does not cut a task short unnecessarily.
+BOOST_AUTO_TEST_CASE(shutdown_timeout_allows_task_to_finish)
+{
+  std::atomic<bool> started{false};
+  std::atomic<bool> completed{false};
+
+  Fmi::ThreadPool::ThreadPool pool(1, 10);
+  pool.setGracefulShutdown(true);
+  pool.start();
+
+  bool inserted = pool.schedule(
+      [&started, &completed]()
+      {
+        started = true;
+        boost::this_thread::sleep_for(boost::chrono::milliseconds(200));
+        completed = true;
+      });
+  BOOST_REQUIRE(inserted);
+
+  while (!started)
+    boost::this_thread::sleep_for(boost::chrono::milliseconds(5));
+
+  const auto t0 = boost::chrono::steady_clock::now();
+  pool.shutdown(5.0);  // generous timeout: the 200 ms task finishes before it elapses
+  const auto elapsed_ms = boost::chrono::duration_cast<boost::chrono::milliseconds>(
+                              boost::chrono::steady_clock::now() - t0)
+                              .count();
+
+  BOOST_TEST_MESSAGE("shutdown(5.0) with a 200 ms task returned after " << elapsed_ms << " ms");
+  BOOST_CHECK(completed);            // graceful shutdown let the running task finish
+  BOOST_CHECK_LT(elapsed_ms, 4000);  // returned well before the timeout
+}


### PR DESCRIPTION
shutdown() gains an optional theTimeoutSeconds argument. When shutting down gracefully with a positive timeout, wait at most that long for workers to finish their current task; if it elapses, fall back to interrupting the workers so shutdown cannot hang indefinitely on a stuck task. A value <= 0 keeps the historical behaviour (wait forever), so existing shutdown() callers are unaffected.

This lets a server bound its stop time (e.g. under systemd TimeoutStopSec) instead of relying on every queued task completing.

Header-only template change: no .so ABI impact, but consumers must recompile. Kept on a branch pending the wider stability work.

List of packages, which requires rebuild:
- smartmet-library-trax (not visible through API, so users of smartmet-library-trax are safe)
- smartmet-server